### PR TITLE
Add enum prefixes

### DIFF
--- a/test_1/GameState.cpp
+++ b/test_1/GameState.cpp
@@ -187,7 +187,7 @@ void GameState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier m
 
 void GameState::onKeyUp(EventHandler::KeyCode key, EventHandler::KeyModifier mod)
 {
-	if(key == EventHandler::KEY_ESCAPE)
+	if(key == EventHandler::KeyCode::KEY_ESCAPE)
 		postQuitEvent();
 }
 

--- a/test_1/GameState.cpp
+++ b/test_1/GameState.cpp
@@ -194,7 +194,7 @@ void GameState::onKeyUp(EventHandler::KeyCode key, EventHandler::KeyModifier mod
 
 void GameState::onMouseDown(EventHandler::MouseButton button, int x, int y)
 {
-	if(button == EventHandler::BUTTON_LEFT)
+	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
 		mGunTimer.reset();
 		mLeftButtonDown = true;
@@ -205,7 +205,7 @@ void GameState::onMouseDown(EventHandler::MouseButton button, int x, int y)
 
 void GameState::onMouseUp(EventHandler::MouseButton button, int x, int y)
 {
-	if(button == EventHandler::BUTTON_LEFT)
+	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
 		mLeftButtonDown = false;
 	}

--- a/test_2/Test2State.cpp
+++ b/test_2/Test2State.cpp
@@ -97,13 +97,13 @@ void Test2State::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier 
 {
 	switch (key)
 	{
-		case EventHandler::KEY_ESCAPE:
+		case EventHandler::KeyCode::KEY_ESCAPE:
 			postQuitEvent();
 			break;
-		case EventHandler::KEY_F1:
+		case EventHandler::KeyCode::KEY_F1:
 			Utility<Renderer>::get().fullscreen(!Utility<Renderer>::get().fullscreen());
 			break;
-		case EventHandler::KEY_F2:
+		case EventHandler::KeyCode::KEY_F2:
 			Utility<Renderer>::get().resizeable(!Utility<Renderer>::get().resizeable());
 			break;
 		default:

--- a/test_3/Test3State.cpp
+++ b/test_3/Test3State.cpp
@@ -98,10 +98,10 @@ void Test3State::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier 
 	if(repeat)
 		return;
 
-	if(key == EventHandler::KEY_ESCAPE)
+	if(key == EventHandler::KeyCode::KEY_ESCAPE)
 		postQuitEvent();
 
-	if(key == EventHandler::KEY_1)
+	if(key == EventHandler::KeyCode::KEY_1)
 	{
 		mAlpha = true;
 		mMultiply = false;
@@ -110,7 +110,7 @@ void Test3State::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier 
 		mMultiply2 = false;
 		mCausticsOnly2 = false;
 	}
-	if(key == EventHandler::KEY_2)
+	if(key == EventHandler::KeyCode::KEY_2)
 	{
 		mAlpha = false;
 		mMultiply = true;
@@ -120,7 +120,7 @@ void Test3State::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier 
 		mCausticsOnly2 = false;
 
 	}
-	if(key == EventHandler::KEY_3)
+	if(key == EventHandler::KeyCode::KEY_3)
 	{
 		mAlpha = false;
 		mMultiply = false;
@@ -130,7 +130,7 @@ void Test3State::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier 
 		mCausticsOnly2 = false;
 
 	}
-	if(key == EventHandler::KEY_4)
+	if(key == EventHandler::KeyCode::KEY_4)
 	{
 		mAlpha = false;
 		mMultiply = false;
@@ -139,7 +139,7 @@ void Test3State::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier 
 		mMultiply2 = false;
 		mCausticsOnly2 = false;
 	}
-	if(key == EventHandler::KEY_5)
+	if(key == EventHandler::KeyCode::KEY_5)
 	{
 		mAlpha = false;
 		mMultiply = false;
@@ -148,7 +148,7 @@ void Test3State::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier 
 		mMultiply2 = true;
 		mCausticsOnly2 = false;
 	}
-	if(key == EventHandler::KEY_6)
+	if(key == EventHandler::KeyCode::KEY_6)
 	{
 		mAlpha = false;
 		mMultiply = false;


### PR DESCRIPTION
Add `enum` prefixes for `KeyCode` and `MouseButton`. These are needed for more recent versions of NAS2D where these two `enum` are switched to `enum class`.