### PR TITLE
Update makefile for better dependency management

### DIFF
--- a/makefile
+++ b/makefile
@@ -27,6 +27,13 @@ test3.exe: | nas2d
 nas2d:
 	+make -C nas2d-core/
 
+.PHONY: clean-nas2d
+clean-nas2d:
+	+make -C nas2d-core/ clean
+.PHONY: clean-all-nas2d
+clean-all-nas2d:
+	+make -C nas2d-core/ clean-all
+
 $(eval $(call DefineCppProject,test1,test1.exe,test_1/))
 $(eval $(call DefineCppProject,test2,test2.exe,test_2/))
 $(eval $(call DefineCppProject,test3,test3.exe,test_3/))

--- a/makefile
+++ b/makefile
@@ -19,9 +19,9 @@ LDLIBS := -lnas2d -lSDL2 -lSDL2_mixer -lSDL2_image -lSDL2_ttf -lphysfs -lGLEW -l
 # By default, compile and link both static library and dynamic link library
 all: test1 test2 test3
 
-test1: | nas2d
-test2: | nas2d
-test3: | nas2d
+test1.exe: | nas2d
+test2.exe: | nas2d
+test3.exe: | nas2d
 
 .PHONY: nas2d
 nas2d:


### PR DESCRIPTION
Have make build the static library before trying to link test executables. Allow for cleaning of NAS2D outputs from the main makefile.
