### PR TITLE
Fix warnings

### DIFF
--- a/test_1/GameState.cpp
+++ b/test_1/GameState.cpp
@@ -11,7 +11,6 @@ using namespace NAS2D;
 
 const int GUN_DELAY_TIME = 210;
 const int GUN_JITTER = 6;
-const int GUN_HALF_JITTER = GUN_JITTER / 2;
 
 const unsigned int	ZOMBIE_DEAD_TIMEOUT		= 8000; // Time, in miliseconds, a dead zombie should continue to exist
 
@@ -41,8 +40,6 @@ GameState::GameState(): mPlayerPosition(Utility<Renderer>::get().center_x(), Uti
 
 void GameState::initialize()
 {
-	Renderer& r = Utility<Renderer>::get();
-
 	spawnSwarm();
 
 	EventHandler& e = Utility<EventHandler>::get();

--- a/test_1/GameState.cpp
+++ b/test_1/GameState.cpp
@@ -22,10 +22,10 @@ auto jitter = std::bind(jitter_distribution, generator);
 
 
 GameState::GameState() :
-	mPlayerPosition(Utility<Renderer>::get().center_x(), Utility<Renderer>::get().center_y()),
 	mZombieSpawnCount(5),
 	mFont("fonts/opensans.ttf", 15),
 	mAnnounceFont("fonts/opensans-bold.ttf", 50),
+	mPlayerPosition(Utility<Renderer>::get().center_x(), Utility<Renderer>::get().center_y()),
 	mPointer("pointer.png"),
 	mBackground("grass_bg.png"),
 	mBulletHole("bullet_hole.png"),

--- a/test_1/GameState.cpp
+++ b/test_1/GameState.cpp
@@ -178,21 +178,21 @@ void GameState::updateZombies()
 }
 
 
-void GameState::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool repeat)
+void GameState::onKeyDown(EventHandler::KeyCode /*key*/, EventHandler::KeyModifier /*mod*/, bool repeat)
 {
 	if(repeat)
 		return;
 }
 
 
-void GameState::onKeyUp(EventHandler::KeyCode key, EventHandler::KeyModifier mod)
+void GameState::onKeyUp(EventHandler::KeyCode key, EventHandler::KeyModifier /*mod*/)
 {
 	if(key == EventHandler::KeyCode::KEY_ESCAPE)
 		postQuitEvent();
 }
 
 
-void GameState::onMouseDown(EventHandler::MouseButton button, int x, int y)
+void GameState::onMouseDown(EventHandler::MouseButton button, int /*x*/, int /*y*/)
 {
 	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
@@ -203,7 +203,7 @@ void GameState::onMouseDown(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void GameState::onMouseUp(EventHandler::MouseButton button, int x, int y)
+void GameState::onMouseUp(EventHandler::MouseButton button, int /*x*/, int /*y*/)
 {
 	if(button == EventHandler::MouseButton::BUTTON_LEFT)
 	{
@@ -212,7 +212,7 @@ void GameState::onMouseUp(EventHandler::MouseButton button, int x, int y)
 }
 
 
-void GameState::onMouseMove(int x, int y, int relX, int relY)
+void GameState::onMouseMove(int x, int y, int /*relX*/, int /*relY*/)
 {
 	mMouseCoords = {x, y};
 }

--- a/test_1/GameState.cpp
+++ b/test_1/GameState.cpp
@@ -21,19 +21,20 @@ std::uniform_int_distribution<int> jitter_distribution(-GUN_JITTER, GUN_JITTER);
 auto jitter = std::bind(jitter_distribution, generator);
 
 
-GameState::GameState(): mPlayerPosition(Utility<Renderer>::get().center_x(), Utility<Renderer>::get().center_y()),
-						mZombieSpawnCount(5),
-						mFont("fonts/opensans.ttf", 15),
-						mAnnounceFont("fonts/opensans-bold.ttf", 50),
-						mPointer("pointer.png"),
-						mBackground("grass_bg.png"),
-						mBulletHole("bullet_hole.png"),
-						mTent("tent.png"),
-						mTentShadow("tent_shadow.png"),
-						mBgMusic("music/clearside-shapeshifter.ogg"),
-						mGunFire("sfx/machine_gun.wav"),
-						mTimeDelta(0),
-						mLeftButtonDown(false)
+GameState::GameState() :
+	mPlayerPosition(Utility<Renderer>::get().center_x(), Utility<Renderer>::get().center_y()),
+	mZombieSpawnCount(5),
+	mFont("fonts/opensans.ttf", 15),
+	mAnnounceFont("fonts/opensans-bold.ttf", 50),
+	mPointer("pointer.png"),
+	mBackground("grass_bg.png"),
+	mBulletHole("bullet_hole.png"),
+	mTent("tent.png"),
+	mTentShadow("tent_shadow.png"),
+	mBgMusic("music/clearside-shapeshifter.ogg"),
+	mGunFire("sfx/machine_gun.wav"),
+	mTimeDelta(0),
+	mLeftButtonDown(false)
 {
 }
 

--- a/test_1/NAS2D_Test.cpp
+++ b/test_1/NAS2D_Test.cpp
@@ -20,7 +20,7 @@
 
 const std::string APPLICATION_TITLE = "NAS2D Sample Application";
 
-int main(int argc, char *argv[])
+int main(int /*argc*/, char *argv[])
 {
 	try
 	{

--- a/test_1/Zombie.cpp
+++ b/test_1/Zombie.cpp
@@ -17,29 +17,31 @@ const std::string		IDLE_WEST				= "WalkWest";
 
 
 
-Zombie::Zombie(float x, float y, float speed):	mSprite(SPRITE_PATH),
-												mPosition(x, y),
-												mHealth(100),
-												mMaxHealth(mHealth),
-												mDirection(0.0f),
-												mSpeed(speed),
-												mSpeedModifier(0.0f),
-												mBodyRect(BOUNDING_BOX_BODY),
-												mHeadRect(BOUNDING_BOX_HEAD)
+Zombie::Zombie(float x, float y, float speed) :
+	mSprite(SPRITE_PATH),
+	mPosition(x, y),
+	mHealth(100),
+	mMaxHealth(mHealth),
+	mDirection(0.0f),
+	mSpeed(speed),
+	mSpeedModifier(0.0f),
+	mBodyRect(BOUNDING_BOX_BODY),
+	mHeadRect(BOUNDING_BOX_HEAD)
 {
 	mSprite.play(IDLE_WEST);
 }
 
 
-Zombie::Zombie(int x, int y, int speed):	mSprite(SPRITE_PATH),
-											mPosition(static_cast<float>(x), static_cast<float>(y)),
-											mHealth(100),
-											mMaxHealth(mHealth),
-											mDirection(0.0f),
-											mSpeed(static_cast<float>(speed)),
-											mSpeedModifier(0.0f),
-											mBodyRect(BOUNDING_BOX_BODY),
-											mHeadRect(BOUNDING_BOX_HEAD)
+Zombie::Zombie(int x, int y, int speed) :
+	mSprite(SPRITE_PATH),
+	mPosition(static_cast<float>(x), static_cast<float>(y)),
+	mHealth(100),
+	mMaxHealth(mHealth),
+	mDirection(0.0f),
+	mSpeed(static_cast<float>(speed)),
+	mSpeedModifier(0.0f),
+	mBodyRect(BOUNDING_BOX_BODY),
+	mHeadRect(BOUNDING_BOX_HEAD)
 {
 	mSprite.play(IDLE_WEST);
 }

--- a/test_1/Zombie.cpp
+++ b/test_1/Zombie.cpp
@@ -1,9 +1,6 @@
 #include "Zombie.h"
 
 
-const int RECT_MARGIN = 7;
-const int RECT_MARGIN_2 = RECT_MARGIN * 2;
-
 const Rectangle_2d		BOUNDING_BOX_BODY		= Rectangle_2d(-10, -40, 14, 46);
 const Rectangle_2d		BOUNDING_BOX_HEAD		= Rectangle_2d(-7, -50, 8, 8);
 

--- a/test_1/Zombie.cpp
+++ b/test_1/Zombie.cpp
@@ -21,7 +21,6 @@ Zombie::Zombie(float x, float y, float speed) :
 	mMaxHealth(mHealth),
 	mDirection(0.0f),
 	mSpeed(speed),
-	mSpeedModifier(0.0f),
 	mBodyRect(BOUNDING_BOX_BODY),
 	mHeadRect(BOUNDING_BOX_HEAD)
 {
@@ -36,7 +35,6 @@ Zombie::Zombie(int x, int y, int speed) :
 	mMaxHealth(mHealth),
 	mDirection(0.0f),
 	mSpeed(static_cast<float>(speed)),
-	mSpeedModifier(0.0f),
 	mBodyRect(BOUNDING_BOX_BODY),
 	mHeadRect(BOUNDING_BOX_HEAD)
 {

--- a/test_1/Zombie.h
+++ b/test_1/Zombie.h
@@ -44,7 +44,6 @@ private:
 	float			mDirection;			/**< Zombie's facing direction. */
 
 	float			mSpeed;				/**< Zombie's speed. */
-	float			mSpeedModifier;		/**< Zombie's speed modifier. */
 
 	Rectangle_2d	mBodyRect;			/**< Area of the Zombie. */
 	Rectangle_2d	mHeadRect;			/**< Area of the Zombie. */

--- a/test_2/NAS2D_Test2.cpp
+++ b/test_2/NAS2D_Test2.cpp
@@ -20,7 +20,7 @@
 const std::string APPLICATION_TITLE = "NAS2D Test 2: Renderer Functions";
 
 
-int main(int argc, char *argv[])
+int main(int /*argc*/, char *argv[])
 {
 
 	try

--- a/test_2/NAS2D_Test2.cpp
+++ b/test_2/NAS2D_Test2.cpp
@@ -1,6 +1,6 @@
 // ==================================================================================
 // = NAS2D Test App 2
-// = Copyright © 2008 - 2019 LairWorks Entertainment
+// = Copyright Â© 2008 - 2019 LairWorks Entertainment
 // ==================================================================================
 // = NAS2D is distributed under the terms of the zlib license. You are free to copy,
 // = modify and distribute the software under the terms of the zlib license.

--- a/test_2/Test2State.cpp
+++ b/test_2/Test2State.cpp
@@ -93,7 +93,7 @@ State* Test2State::update()
 }
 
 
-void Test2State::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool repeat)
+void Test2State::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /*mod*/, bool /*repeat*/)
 {
 	switch (key)
 	{
@@ -112,13 +112,13 @@ void Test2State::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier 
 }
 
 
-void Test2State::onMouseMove(int x, int y, int relX, int relY)
+void Test2State::onMouseMove(int /*x*/, int /*y*/, int /*relX*/, int /*relY*/)
 {}
 
 
-void Test2State::onMouseDown(EventHandler::MouseButton button, int x, int y)
+void Test2State::onMouseDown(EventHandler::MouseButton /*button*/, int /*x*/, int /*y*/)
 {}
 
 
-void Test2State::onWindowResized(int w, int h)
+void Test2State::onWindowResized(int /*w*/, int /*h*/)
 {}

--- a/test_3/NAS2D_Test3_Blending.cpp
+++ b/test_3/NAS2D_Test3_Blending.cpp
@@ -16,7 +16,7 @@
 
 const std::string APPLICATION_TITLE = "NAS2D Test App3";
 
-int main(int argc, char* argv[])
+int main(int /*argc*/, char* argv[])
 {
 	try
 	{

--- a/test_3/Test3State.cpp
+++ b/test_3/Test3State.cpp
@@ -10,19 +10,20 @@ const int	TILE_SIZE			= 256;
 
 using namespace std;
 
-Test3State::Test3State():	mFont("fonts/opensans-bold.ttf", 25),
-							mSmallFont("fonts/opensans.ttf", 14),
-							mMud("mud.png"),
-							mCaustics("caustics_atlas.png"),
-							mCaustics2("caustics_atlas_noalpha.png"),
-							mCaustics3("caustics_atlas_2.png"),
-							mCaustics4("caustics_atlas_2_noalpha.png"),
-							mAlpha(true),
-							mMultiply(false),
-							mCausticsOnly(false),
-							mAlpha2(false),
-							mMultiply2(false),
-							mCausticsOnly2(false)
+Test3State::Test3State() :
+	mFont("fonts/opensans-bold.ttf", 25),
+	mSmallFont("fonts/opensans.ttf", 14),
+	mMud("mud.png"),
+	mCaustics("caustics_atlas.png"),
+	mCaustics2("caustics_atlas_noalpha.png"),
+	mCaustics3("caustics_atlas_2.png"),
+	mCaustics4("caustics_atlas_2_noalpha.png"),
+	mAlpha(true),
+	mMultiply(false),
+	mCausticsOnly(false),
+	mAlpha2(false),
+	mMultiply2(false),
+	mCausticsOnly2(false)
 {
 }
 

--- a/test_3/Test3State.cpp
+++ b/test_3/Test3State.cpp
@@ -49,9 +49,9 @@ State* Test3State::update()
 			counter = 0;
 	}
 
-	for(size_t col = 0; col < divideUp(r.height(), TILE_SIZE); col++)
+	for(int col = 0; col < divideUp(r.height(), TILE_SIZE); col++)
 	{
-		for(size_t row = 0; row < divideUp(r.width(), TILE_SIZE); row++)
+		for(int row = 0; row < divideUp(r.width(), TILE_SIZE); row++)
 		{
 			r.drawImage(mMud, row * 256, col * 256);
 		}
@@ -59,9 +59,9 @@ State* Test3State::update()
 
 	if(mMultiply || mMultiply2)
 		glBlendFunc(GL_SRC_COLOR, GL_DST_COLOR);
-	for(size_t col = 0; col < divideUp(r.height(), TILE_SIZE); col++)
+	for(int col = 0; col < divideUp(r.height(), TILE_SIZE); col++)
 	{
-		for(size_t row = 0; row < divideUp(r.width(), TILE_SIZE); row++)
+		for(int row = 0; row < divideUp(r.width(), TILE_SIZE); row++)
 		{
 			if(mAlpha)
 				r.drawSubImage(mCaustics, row * TILE_SIZE, col * TILE_SIZE, (counter % 4) * TILE_SIZE, ((counter % 16) / 4) * TILE_SIZE, TILE_SIZE, TILE_SIZE);

--- a/test_3/Test3State.cpp
+++ b/test_3/Test3State.cpp
@@ -94,7 +94,7 @@ State* Test3State::update()
 
 
 
-void Test3State::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool repeat)
+void Test3State::onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier /*mod*/, bool repeat)
 {
 	if(repeat)
 		return;


### PR DESCRIPTION
Fix Clang compiler warnings:
- unused parameters
- unused member fields
- unused variables
- initializer list ordering
- signed/unsigned comparisons
- indentation
