### PR TITLE
Import test data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 /proj/vs2019/Release_test3
 /proj/vs2019/x64
 /.build
-/data
 /*.dll
 /*.exe
 *.db

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "nas2d-core"]
 	path = nas2d-core
 	url = https://github.com/lairworks/nas2d-core.git
+[submodule "data"]
+	path = data
+	url = https://github.com/lairworks/nas2d-assets.git


### PR DESCRIPTION
Add the `nas2d-assets` repository as a Git submodule for the `"data/"` folder. This allows the test projects to find the assets they are referencing.

Closes #8.
