### PR TITLE
Update constructor initializer list formatting

### DIFF
--- a/test_2/Test2State.cpp
+++ b/test_2/Test2State.cpp
@@ -12,10 +12,11 @@ std::uniform_int_distribution<int> jitter_distribution(0, 64);
 auto jitter = std::bind(jitter_distribution, generator);
 
 
-Test2State::Test2State():	mFont("fonts/opensans-bold.ttf", 16),
-							mImage1("mud.png"),
-							mArrows("arrows.png"),
-							mRenderTarget(256, 256)
+Test2State::Test2State() :
+	mFont("fonts/opensans-bold.ttf", 16),
+	mImage1("mud.png"),
+	mArrows("arrows.png"),
+	mRenderTarget(256, 256)
 {}
 
 


### PR DESCRIPTION
Make the constructor initializer list formatting match the style used in the other test projects.
