### PR TITLE
Replace `arrows.png` with different file that exists

### DIFF
--- a/test_2/Test2State.cpp
+++ b/test_2/Test2State.cpp
@@ -15,7 +15,7 @@ auto jitter = std::bind(jitter_distribution, generator);
 Test2State::Test2State() :
 	mFont("fonts/opensans-bold.ttf", 16),
 	mImage1("mud.png"),
-	mArrows("arrows.png"),
+	mArrows("gui/default/arrow.png"),
 	mRenderTarget(256, 256)
 {}
 


### PR DESCRIPTION
The new file probably doesn't quite match what the old file was supposed to be, but it's close enough to get the code to run.

Can always update it later to a better file, or add the missing asset.
