### PR TITLE
Add missing `override` keywords

### DIFF
--- a/test_1/GameState.h
+++ b/test_1/GameState.h
@@ -11,8 +11,8 @@ public:
 	GameState();
 
 protected:
-	void initialize();
-	State* update();
+	void initialize() override;
+	State* update() override;
 
 	void onKeyUp(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod);
 	void onKeyDown(NAS2D::EventHandler::KeyCode key, NAS2D::EventHandler::KeyModifier mod, bool repeat);

--- a/test_2/Test2State.h
+++ b/test_2/Test2State.h
@@ -9,8 +9,8 @@ public:
 	~Test2State();
 
 protected:
-	void initialize();
-	State* update();
+	void initialize() override;
+	State* update() override;
 
 
 	void onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool repeat);

--- a/test_3/Test3State.h
+++ b/test_3/Test3State.h
@@ -8,8 +8,8 @@ public:
 	Test3State();
 
 protected:
-	void initialize();
-	State* update();
+	void initialize() override;
+	State* update() override;
 
 	void onKeyDown(EventHandler::KeyCode key, EventHandler::KeyModifier mod, bool repeat);
 


### PR DESCRIPTION
Add `override` keyword where possible.

These were found with the GCC flag `-Wsuggest-override`. This flag is not available for Clang, so has not been enabled globally.
