### PR TITLE
Fix health bar offset

### DIFF
--- a/test_1/Zombie.cpp
+++ b/test_1/Zombie.cpp
@@ -6,7 +6,7 @@ constexpr auto BodyOffset = NAS2D::Vector<int>{-10, -40};
 constexpr auto HeadSize = NAS2D::Vector<int>{8, 8};
 constexpr auto HeadOffset = NAS2D::Vector<int>{-7, -50};
 constexpr auto HealthMeterSize = NAS2D::Vector<int>{24, 2};
-constexpr auto HealthMeterOffset = NAS2D::Vector<int>{-HealthMeterSize.x / 2, -12};
+constexpr auto HealthMeterOffset = NAS2D::Vector<int>{-HealthMeterSize.x / 2, -55};
 
 
 Zombie::Zombie(NAS2D::Point_2df position, float speed) :


### PR DESCRIPTION
The vertical offset was accidentally set incorrectly during a recent code refactor.

See 0520694829ba0dc30a18cce40063e58a430e7541 for the problem commit.

The hardcoded offset of `-5` was accidentally combined with the `x` offset for the head (`-7`), instead of the `y` offset for the head (`-50`).
