### PR TITLE
Use explicitly typed parameter to silence MSVC warning

### DIFF
--- a/test_1/GameState.cpp
+++ b/test_1/GameState.cpp
@@ -130,7 +130,7 @@ void GameState::handlePlayerAction()
 void GameState::spawnSwarm()
 {
 	for(size_t i = 0; i < mZombieSpawnCount; i++)
-		mZombies.push_back(Zombie{NAS2D::Point<float>{static_cast<float>(i) * 200, -20}, 0.015});
+		mZombies.push_back(Zombie{NAS2D::Point<float>{static_cast<float>(i) * 200, -20}, 0.015f});
 
 	mZombieSpawnCount += 2;
 }


### PR DESCRIPTION
MSVC was warning:
warning C4305: 'argument': truncation from 'double' to 'float'