### PR TITLE
Simplify direction calculation

### DIFF
--- a/SampleProjects/ZombieGame/Zombie.cpp
+++ b/SampleProjects/ZombieGame/Zombie.cpp
@@ -30,7 +30,7 @@ void Zombie::update(int timeDelta, NAS2D::Point<float> playerPosition)
 		return;
 
 	// Ultra basic bee-line AI
-	const auto direction = NAS2D::angleFromPoints(mPosition.x, mPosition.y, playerPosition.x, playerPosition.y);
+	const auto direction = NAS2D::getAngle(playerPosition - mPosition);
 	mPosition += NAS2D::getDirectionVector(direction) * (timeDelta * mSpeed);
 
 	// Update bounding boxes.

--- a/SampleProjects/ZombieGame/Zombie.cpp
+++ b/SampleProjects/ZombieGame/Zombie.cpp
@@ -14,7 +14,6 @@ Zombie::Zombie(NAS2D::Point<float> position, float speed) :
 	mPosition(position),
 	mHealth(100),
 	mMaxHealth(mHealth),
-	mDirection(0.0f),
 	mSpeed(speed),
 	mBodyRect(NAS2D::Rectangle<int>::Create(mPosition.to<int>() + BodyOffset, BodySize)),
 	mHeadRect(NAS2D::Rectangle<int>::Create(mPosition.to<int>() + HeadOffset, HeadSize))
@@ -31,8 +30,8 @@ void Zombie::update(int timeDelta, NAS2D::Point<float> playerPosition)
 		return;
 
 	// Ultra basic bee-line AI
-	mDirection = NAS2D::angleFromPoints(mPosition.x, mPosition.y, playerPosition.x, playerPosition.y);
-	mPosition += NAS2D::getDirectionVector(mDirection) * (timeDelta * mSpeed);
+	const auto direction = NAS2D::angleFromPoints(mPosition.x, mPosition.y, playerPosition.x, playerPosition.y);
+	mPosition += NAS2D::getDirectionVector(direction) * (timeDelta * mSpeed);
 
 	// Update bounding boxes.
 	mBodyRect = NAS2D::Rectangle<int>::Create(mPosition.to<int>() + BodyOffset, BodySize);

--- a/SampleProjects/ZombieGame/Zombie.h
+++ b/SampleProjects/ZombieGame/Zombie.h
@@ -27,7 +27,6 @@ private:
 	int mHealth; /**< Zombie's health. */
 	int mMaxHealth; /**< Zombie's max health. */
 
-	float mDirection; /**< Zombie's facing direction. */
 	float mSpeed; /**< Zombie's speed in pixels per update. */
 
 	NAS2D::Rectangle<int> mBodyRect; /**< Area of the Zombie. */


### PR DESCRIPTION
Use packed parameter method to convert `Vector` to angle, and use local variable instead of member variable.

Technically, we can avoid the trig functions entirely. We could instead divide the direction vector by its length to get a unit vector in the appropriate direction. That direction unit vector can then be scaled by the movement rate to get the actual movement. Of course, there are no current methods to get the length of a `Vector`, only the `lengthSquared()`.

----

Related: #49, https://github.com/lairworks/nas2d-core/pull/692
