### PR TITLE
Move Zombies to dead list for greater efficiency

### DIFF
--- a/SampleProjects/ZombieGame/GameState.cpp
+++ b/SampleProjects/ZombieGame/GameState.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <random>
 #include <string>
+#include <utility>
 
 
 const int GunDelayTime = 210;
@@ -93,7 +94,7 @@ void GameState::doShoot()
 			mZombies[i].damage(10, mBulletPoint);
 			if (mZombies[i].dead())
 			{
-				mDeadZombies.push_back(mZombies[i]);
+				mDeadZombies.push_back(std::move(mZombies[i]));
 				mZombies.erase(mZombies.begin() + i);
 			}
 			return;


### PR DESCRIPTION
This is also to work around a potential issue where copying a `Zombie` object will copy the contained `Sprite` object, which is currently large and slow, and with a recent optimization, possibly incorrect due to invalidation of cached pointers during the copy.
