### PR TITLE
Fix icon access

### DIFF
--- a/SampleProjects/RendererFunctions/main.cpp
+++ b/SampleProjects/RendererFunctions/main.cpp
@@ -24,6 +24,7 @@ int main(int /*argc*/, char *argv[])
 	try
 	{
 		NAS2D::Game game("NAS2D Test 2: Renderer Functions", "NAS2D_Test2", "LairWorks Entertainment", argv[0]);
+		NAS2D::Utility<NAS2D::Filesystem>::get().mount("SampleProjects/RendererFunctions/");
 		game.go(new Test2State());
 	}
 	catch(std::exception& e)


### PR DESCRIPTION
A NAS2D update will `throw` an exception if a window icon can't be found. This reveals a resource search path problem for the RendererFunctions project. Adding the project source folder allows the icon file to be found, which prevents aborting with an error.

One odd point to note, is the icon doesn't seem to appear on Ubuntu Linux. Not sure if this is a platform specific problem, or a more general problem displaying window icons. @ldicker83, could you check if the window icon displays correctly on Windows?

----

Reference: https://github.com/lairworks/nas2d-core/pull/908
