### PR TITLE
Fix Zombie game resolution

### DIFF
--- a/SampleProjects/ZombieGame/main.cpp
+++ b/SampleProjects/ZombieGame/main.cpp
@@ -24,6 +24,7 @@ int main(int /*argc*/, char *argv[])
 	try
 	{
 		NAS2D::Game game("NAS2D Sample Application", "NAS2D_Test", "LairWorks Entertainment", argv[0]);
+		NAS2D::Utility<NAS2D::Renderer>::get().size({800, 600});
 		game.go(new GameState());
 	}
 	catch(std::exception& e)


### PR DESCRIPTION
Set the window resolution to what the game was designed for, rather than the arbitrary default value set in NAS2D.

This is important for when the game settings file does not exist, such as for a fresh install. It seems this was broken for a long time and was not noticed because we always had the config file around from previous runs.

----

Related: https://github.com/lairworks/nas2d-core/pull/907
