### PR TITLE
Refactor loops

### DIFF
--- a/SampleProjects/ZombieGame/GameState.cpp
+++ b/SampleProjects/ZombieGame/GameState.cpp
@@ -87,16 +87,16 @@ void GameState::doShoot()
 
 	NAS2D::Utility<NAS2D::Mixer>::get().playSound(mGunFire);
 
-	for(size_t i = 0; i < mZombies.size(); i++)
+	for(auto iter = mZombies.begin(); iter != mZombies.end(); ++iter)
 	{
-		auto& zombie = mZombies[i];
+		auto& zombie = *iter;
 		if (zombie.hit(mBulletPoint))
 		{
 			zombie.damage(10, mBulletPoint);
 			if (zombie.dead())
 			{
 				mDeadZombies.push_back(std::move(zombie));
-				mZombies.erase(mZombies.begin() + i);
+				mZombies.erase(iter);
 			}
 			return;
 		}

--- a/SampleProjects/ZombieGame/GameState.cpp
+++ b/SampleProjects/ZombieGame/GameState.cpp
@@ -141,9 +141,9 @@ void GameState::spawnSwarm()
 
 void GameState::updateZombies()
 {
-	for(size_t i = 0; i < mDeadZombies.size(); i++)
+	for(auto& deadZombie : mDeadZombies)
 	{
-		mDeadZombies[i].update(0, mPlayerPosition);
+		deadZombie.update(0, mPlayerPosition);
 	}
 
 	mDeadZombies.erase(

--- a/SampleProjects/ZombieGame/GameState.cpp
+++ b/SampleProjects/ZombieGame/GameState.cpp
@@ -147,9 +147,9 @@ void GameState::updateZombies()
 			mDeadZombies.erase(mDeadZombies.begin() + i);
 	}
 
-	for(size_t i = 0; i < mZombies.size(); i++)
+	for(auto& zombie : mZombies)
 	{
-		mZombies[i].update(mTimeDelta, mPlayerPosition);
+		zombie.update(mTimeDelta, mPlayerPosition);
 	}
 }
 

--- a/SampleProjects/ZombieGame/GameState.cpp
+++ b/SampleProjects/ZombieGame/GameState.cpp
@@ -5,6 +5,7 @@
 #include <random>
 #include <string>
 #include <utility>
+#include <algorithm>
 
 
 const int GunDelayTime = 210;
@@ -143,10 +144,16 @@ void GameState::updateZombies()
 	for(size_t i = 0; i < mDeadZombies.size(); i++)
 	{
 		mDeadZombies[i].update(0, mPlayerPosition);
-
-		if (mDeadZombies[i].deadTime() >= ZombieDeadTimeout)
-			mDeadZombies.erase(mDeadZombies.begin() + i);
 	}
+
+	mDeadZombies.erase(
+		std::remove_if(
+			mDeadZombies.begin(),
+			mDeadZombies.end(),
+			[](auto& zombie) { return zombie.deadTime() >= ZombieDeadTimeout; }
+		),
+		mDeadZombies.end()
+	);
 
 	for(auto& zombie : mZombies)
 	{

--- a/SampleProjects/ZombieGame/GameState.cpp
+++ b/SampleProjects/ZombieGame/GameState.cpp
@@ -89,12 +89,13 @@ void GameState::doShoot()
 
 	for(size_t i = 0; i < mZombies.size(); i++)
 	{
-		if (mZombies[i].hit(mBulletPoint))
+		auto& zombie = mZombies[i];
+		if (zombie.hit(mBulletPoint))
 		{
-			mZombies[i].damage(10, mBulletPoint);
-			if (mZombies[i].dead())
+			zombie.damage(10, mBulletPoint);
+			if (zombie.dead())
 			{
-				mDeadZombies.push_back(std::move(mZombies[i]));
+				mDeadZombies.push_back(std::move(zombie));
 				mZombies.erase(mZombies.begin() + i);
 			}
 			return;


### PR DESCRIPTION
Prefer using range-for loops for `Zombie` collections.

Avoid undefined behavior by using `std::erase` and `std::remove_if`, rather than iterating forwards through the collection and calling `erase`. Using forward iteration can cause problems with the end of the array moving as items are erased, and items moving backwards as they are erased, potentially causing them to be skipped.
