### PR TITLE
Preconstruct `DelegateX` before calling `connect`/`disconnect`

### DIFF
--- a/SampleProjects/BlendingModes/Test3State.cpp
+++ b/SampleProjects/BlendingModes/Test3State.cpp
@@ -27,7 +27,7 @@ Test3State::Test3State() :
 void Test3State::initialize()
 {
 	NAS2D::Utility<NAS2D::Renderer>::get().showSystemPointer(true);
-	NAS2D::Utility<NAS2D::EventHandler>::get().keyDown().connect(this, &Test3State::onKeyDown);
+	NAS2D::Utility<NAS2D::EventHandler>::get().keyDown().connect({this, &Test3State::onKeyDown});
 }
 
 

--- a/SampleProjects/RendererFunctions/Test2State.cpp
+++ b/SampleProjects/RendererFunctions/Test2State.cpp
@@ -21,19 +21,19 @@ Test2State::Test2State() :
 Test2State::~Test2State()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.mouseMotion().disconnect(this, &Test2State::onMouseMove);
-	eventHandler.mouseButtonDown().disconnect(this, &Test2State::onMouseDown);
-	eventHandler.keyDown().disconnect(this, &Test2State::onKeyDown);
-	eventHandler.windowResized().disconnect(this, &Test2State::onWindowResized);
+	eventHandler.mouseMotion().disconnect({this, &Test2State::onMouseMove});
+	eventHandler.mouseButtonDown().disconnect({this, &Test2State::onMouseDown});
+	eventHandler.keyDown().disconnect({this, &Test2State::onKeyDown});
+	eventHandler.windowResized().disconnect({this, &Test2State::onWindowResized});
 }
 
 void Test2State::initialize()
 {
 	auto& eventHandler = NAS2D::Utility<NAS2D::EventHandler>::get();
-	eventHandler.mouseMotion().connect(this, &Test2State::onMouseMove);
-	eventHandler.mouseButtonDown().connect(this, &Test2State::onMouseDown);
-	eventHandler.keyDown().connect(this, &Test2State::onKeyDown);
-	eventHandler.windowResized().connect(this, &Test2State::onWindowResized);
+	eventHandler.mouseMotion().connect({this, &Test2State::onMouseMove});
+	eventHandler.mouseButtonDown().connect({this, &Test2State::onMouseDown});
+	eventHandler.keyDown().connect({this, &Test2State::onKeyDown});
+	eventHandler.windowResized().connect({this, &Test2State::onWindowResized});
 
 	auto& renderer = NAS2D::Utility<NAS2D::Renderer>::get();
 	renderer.showSystemPointer(true);

--- a/SampleProjects/ZombieGame/GameState.cpp
+++ b/SampleProjects/ZombieGame/GameState.cpp
@@ -40,12 +40,12 @@ void GameState::initialize()
 	spawnSwarm();
 
 	auto& e = NAS2D::Utility<NAS2D::EventHandler>::get();
-	e.keyUp().connect(this, &GameState::onKeyUp);
-	e.keyDown().connect(this, &GameState::onKeyDown);
-	e.mouseMotion().connect(this, &GameState::onMouseMove);
-	e.mouseButtonUp().connect(this, &GameState::onMouseUp);
-	e.mouseButtonDown().connect(this, &GameState::onMouseDown);
-	e.quit().connect(this, &GameState::onQuit);
+	e.keyUp().connect({this, &GameState::onKeyUp});
+	e.keyDown().connect({this, &GameState::onKeyDown});
+	e.mouseMotion().connect({this, &GameState::onMouseMove});
+	e.mouseButtonUp().connect({this, &GameState::onMouseUp});
+	e.mouseButtonDown().connect({this, &GameState::onMouseDown});
+	e.quit().connect({this, &GameState::onQuit});
 
 	NAS2D::Utility<NAS2D::Mixer>::get().playMusic(mBgMusic);
 }


### PR DESCRIPTION
This means fewer overloaded methods will be needed on the `SignalSource` object. It also more tightly associates `this` pointers with member function pointers by composing them into an obvious compound object.

One reason to want to reduce `connect` overloads, is to add debugging capabilities to the `connect` method. This is easier when only a single overload needs to be updated.

Reference: https://github.com/OutpostUniverse/OPHD/pull/1271
