### PR TITLE
Upgrade GitHub Action references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,16 +22,16 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Checkout NAS2D
       run: git submodule update --init nas2d-core/
 
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.3.2
 
     - name: Restore vcpkg dependency cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache
       with:
         path: vcpkg_installed


### PR DESCRIPTION
Older actions relied on older versions of Node, which have been deprecated. Referenced actions should use Node 20, rather than Node 16 or Node 12. Additionally, referenced actions should use `$GITHUB_OUTPUT` instead of `set-output`.

Example run showing warnings (See "Annotations" at the bottom of the summary page):
- https://github.com/lairworks/nas2d-tests/actions/runs/7706718435

Additional reading:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
